### PR TITLE
Reorder conditions for increasing efficiency

### DIFF
--- a/js/wiki-repository.js
+++ b/js/wiki-repository.js
@@ -167,9 +167,9 @@ const WikiRepository = {
 
                     // Pick only homewiki rights that are in relevant user groups
                     user['rights'] = user['rights'].filter(
-                        item => 'groups' in item &&
-                        item.groups.some(r => relevantGroups.includes(r.toLowerCase())) &&
-                        item.wiki === user['home']
+                        item => item.wiki === user['home'] &&
+                        'groups' in item &&
+                        item.groups.some(r => relevantGroups.includes(r.toLowerCase()))
                     );
 
                     // Make sure users have a group and relevant groups


### PR DESCRIPTION
Short-circuit `&&` operator would make `item.wiki === user['home'] && ... && item.groups.some(r => relevantGroups.includes(r.toLowerCase()))` much faster than the other way because `Array.prototype.some` needs to iterate through group-list which may not even be relevant.